### PR TITLE
Add * after required variables

### DIFF
--- a/src/components/ExtensionConfigurationVariableInput.tsx
+++ b/src/components/ExtensionConfigurationVariableInput.tsx
@@ -11,18 +11,26 @@ interface ExtensionConfigurationVariableInputProperties {
 }
 
 export function ExtensionConfigurationVariableInput({
-                                                      configurationVariable,
-                                                      value,
-                                                      onInputChange,
-                                                    }: ExtensionConfigurationVariableInputProperties) {
+  configurationVariable,
+  value,
+  onInputChange,
+}: ExtensionConfigurationVariableInputProperties) {
   const { title, type, options, required } = configurationVariable
-  const { register, formState: { errors } } = useFormContext()
+  const {
+    register,
+    formState: { errors },
+  } = useFormContext()
 
   if (type === 'select' && options && options.length > 0) {
     return (
       <>
         <IonItem>
-          <IonSelect label={'Pick a ' + title} value={value} onIonChange={event => onInputChange(event.target.value)} {...register(configurationVariable.name, { required })}>
+          <IonSelect
+            label={'Pick a ' + title + (required ? ' *' : '')}
+            value={value}
+            onIonChange={(event) => onInputChange(event.target.value)}
+            {...register(configurationVariable.name, { required })}
+          >
             {options.map((option, index) => (
               <IonSelectOption key={index} value={option.value}>
                 {option.name}
@@ -40,7 +48,7 @@ export function ExtensionConfigurationVariableInput({
           <IonInput
             required={required}
             type={type as TextFieldTypes}
-            label={title}
+            label={title + (required ? ' *' : '')}
             value={value}
             labelPlacement={'floating'}
             {...register(configurationVariable.name, { required })}

--- a/src/pages/settings/ExtensionPropertiesScreen.tsx
+++ b/src/pages/settings/ExtensionPropertiesScreen.tsx
@@ -14,16 +14,10 @@ const pageName = 'Extension properties'
 interface ExtensionPropertiesScreenProperties
   extends RouteComponentProps<{
     extensionName: string
-  }> {
-}
+  }> {}
 
 export function ExtensionPropertiesScreen({ match }: ExtensionPropertiesScreenProperties) {
-  const {
-    extension,
-    isGettingExtension,
-    isErrorGettingExtension,
-    putConfiguration,
-  } = useExtension(match.params.extensionName)
+  const { extension, isGettingExtension, isErrorGettingExtension, putConfiguration } = useExtension(match.params.extensionName)
   const [inputValues, setInputValues] = useState<Record<string, unknown>>({})
   const methods = useForm()
   const history = useHistory()
@@ -31,7 +25,7 @@ export function ExtensionPropertiesScreen({ match }: ExtensionPropertiesScreenPr
   useEffect(() => {
     // Load values of extension variables if they are already present in local storage
     if (extension) {
-      ExtensionService.getExtensionConfigurationVariables(extension).then(variables => setInputValues(variables))
+      ExtensionService.getExtensionConfigurationVariables(extension).then((variables) => setInputValues(variables))
     }
   }, [extension])
 
@@ -61,16 +55,16 @@ export function ExtensionPropertiesScreen({ match }: ExtensionPropertiesScreenPr
           {extension &&
             extension.configurationVariables &&
             extension.configurationVariables.map((configurationVariable: ExtensionConfigurationVariable) => (
-                <ExtensionConfigurationVariableInput
-                  key={configurationVariable.name}
-                  configurationVariable={configurationVariable}
-                  value={inputValues[configurationVariable.name] as string}
-                  onInputChange={(value: string) => handleInputChange(configurationVariable.name, value)}
-                />
+              <ExtensionConfigurationVariableInput
+                key={configurationVariable.name}
+                configurationVariable={configurationVariable}
+                value={inputValues[configurationVariable.name] as string}
+                onInputChange={(value: string) => handleInputChange(configurationVariable.name, value)}
+              />
             ))}
 
           {extension && extension.configurationVariables && (
-            <IonButton className={"ion-margin-top"} type={'submit'}>
+            <IonButton className={'ion-margin-top'} type={'submit'}>
               Save properties
             </IonButton>
           )}


### PR DESCRIPTION
### 🛠 Changes being made
Adding a * after required input fields while editing the properties of an extension

### ✨ What's the context?
It was not obvious to a user which input fields have to be filled in in order for an extension to work.

### 🧠 Rationale behind the change
Many uis indicate required fields by adding a * at the end of an input field label.

### 📸 Screenshots (optional)
Added a * after the label of input fields on ExtensionPropertiesScreen

### 🏎 Quality check
- [X] Are there any errors, console logs, debuggers or leftover code in your changes?
- [X] Did you update the documentation for your code?

### Issues
- Closing #2 
