### PR TITLE
Fix bug landmark id not being set to 0

### DIFF
--- a/src/services/TripService.ts
+++ b/src/services/TripService.ts
@@ -23,6 +23,7 @@ async function removeLandmarkFromTrip(landmark: Landmark): Promise<void> {
 async function startTrip(): Promise<void> {
   const trip = (await IonicStorage.get('trip')) as Trip
   trip.started = true
+  trip.nextLandmarkId = 0
   await IonicStorage.set('trip', trip)
 }
 


### PR DESCRIPTION
### 🛠 Changes being made
When starting a trip set next landmark id to 0.

### ✨ What's the context?
When starting a trip the nextLandmarkId stayed -1 and crashed the application.

### 🧠 Rationale behind the change
Otherwise we can't start a trip.

### 🧪 Testing
Manual test.

### 🏎 Quality check
- [x] Are there any errors, console logs, debuggers or leftover code in your changes?
- [x] Did you update the documentation for your code?
