### PR TITLE
Fix bug: scrollable loading page

### DIFF
--- a/src/pages/MapScreen.tsx
+++ b/src/pages/MapScreen.tsx
@@ -38,9 +38,7 @@ export function MapScreen() {
   if (locationNotEnabled) {
     return (
       <IonPage>
-        <IonContent className="ion-padding">
           <LoadingIndicator text="Loading map..." />
-        </IonContent>
       </IonPage>
     )
   }


### PR DESCRIPTION
### 🛠 Changes being made
- Removed additional IonContent tag with extra padding

### ✨ What's the context?
Padding caused an overflow for the loading screen.

### 🧪 Testing
Scrollbar disappeared when applying the new layout without a tag.

### 📸 Screenshots (optional)
Before (with scrollbar)
![image](https://github.com/BauwenDR/osta/assets/101172722/60ea8ff5-c564-4a94-9ae9-18bc7b114130)

After (without)
![image](https://github.com/BauwenDR/osta/assets/101172722/59ff3b5a-7643-4770-950e-b6bfe85c994e)

### 🏎 Quality check
- [x] Are there any errors, console logs, debuggers or leftover code in your changes?
- [x] Did you update the documentation for your code?

### 🐛 Linked issues
Write down all related issues to the pull request here. Use the closing syntax when an issue is deemed as resolved.

- Closes #35 
