### PR TITLE
Add slider to delete landmarks when planning a new trip

### DIFF
--- a/src/pages/MapScreen.tsx
+++ b/src/pages/MapScreen.tsx
@@ -38,9 +38,7 @@ export function MapScreen() {
   if (locationNotEnabled) {
     return (
       <IonPage>
-        <IonContent className="ion-padding">
           <LoadingIndicator text="Loading map..." />
-        </IonContent>
       </IonPage>
     )
   }

--- a/src/pages/trip/CreateTripScreen.tsx
+++ b/src/pages/trip/CreateTripScreen.tsx
@@ -89,7 +89,7 @@ export function CreateTripScreen() {
         </>
       </IonList>
 
-      <IonButton className="btn__home btn__download" routerLink="/trip/plan" disabled={trip && trip.landmarks.length === 0}>
+      <IonButton className="btn__home btn__download btn__color" routerLink="/trip/plan" disabled={trip && trip.landmarks.length === 0}>
         Plan route
       </IonButton>
     </AppScreen>

--- a/src/pages/trip/OrganiseTripScreen.tsx
+++ b/src/pages/trip/OrganiseTripScreen.tsx
@@ -1,5 +1,4 @@
 import {
-  IonAlert,
   IonButton,
   IonItem,
   IonItemOption,
@@ -98,15 +97,7 @@ export function OrganiseTripScreen() {
       <IonButton className="btn__home btn__download btn__color" routerLink={'/map'} onClick={saveTrip}>
         Confirm trip
       </IonButton>
-
-      {/* Alert component */}
-      <IonAlert
-        isOpen={showAlert}
-        onDidDismiss={() => setShowAlert(false)}
-        header="Can't do that right now."
-        message="Where would you be going without a landmark?"
-        buttons={['OK']}
-      />
+      <WarningPopup title="Can't do that right now." message="Where would you be going without a landmark?" isOpen={showAlert} />
     </AppScreen>
   )
 }

--- a/src/pages/trip/OrganiseTripScreen.tsx
+++ b/src/pages/trip/OrganiseTripScreen.tsx
@@ -41,7 +41,7 @@ export function OrganiseTripScreen() {
 
   const removeLandmarkFromTrip = (landmarkId: string) => {
     if (trip && trip.landmarks.length > 1) {
-      const landmark = trip?.landmarks.find((landmark) => landmark.id === landmarkId)
+      const landmark = trip.landmarks.find((landmark) => landmark.id === landmarkId)
       if (landmark) {
         changeTrip({ landmark, addToTrip: false })
       }

--- a/src/pages/trip/OrganiseTripScreen.tsx
+++ b/src/pages/trip/OrganiseTripScreen.tsx
@@ -1,4 +1,5 @@
 import {
+  IonAlert,
   IonButton,
   IonItem,
   IonItemOption,
@@ -97,7 +98,15 @@ export function OrganiseTripScreen() {
       <IonButton className="btn__home btn__download btn__color" routerLink={'/map'} onClick={saveTrip}>
         Confirm trip
       </IonButton>
-      <WarningPopup title="Can't do that right now." message="Where would you be going without a landmark?" isOpen={showAlert} />
+
+      {/* Alert component */}
+      <IonAlert
+        isOpen={showAlert}
+        onDidDismiss={() => setShowAlert(false)}
+        header="Can't do that right now."
+        message="Where would you be going without a landmark?"
+        buttons={['OK']}
+      />
     </AppScreen>
   )
 }

--- a/src/pages/trip/OrganiseTripScreen.tsx
+++ b/src/pages/trip/OrganiseTripScreen.tsx
@@ -95,7 +95,7 @@ export function OrganiseTripScreen() {
           </IonItemSliding>
         ))}
       </IonReorderGroup>
-      <IonButton routerLink={'/map'} onClick={saveTrip}>
+      <IonButton className="btn__home btn__download btn__color" routerLink={'/map'} onClick={saveTrip}>
         Confirm trip
       </IonButton>
 

--- a/src/pages/trip/OrganiseTripScreen.tsx
+++ b/src/pages/trip/OrganiseTripScreen.tsx
@@ -23,7 +23,7 @@ import LocationHelper from '../../helpers/LocationHelper'
 const pageName = 'Create route'
 
 export function OrganiseTripScreen() {
-  const [showAlert, setShowAlert] = useState(false)
+  const [showDeletingNotPossibleAlert, setShowDeletingNotPossibleAlert] = useState(false)
   const { trip, isGettingTrip, isErrorGettingTrip, isErrorChangingTrip, changeTripOrder, startTrip, changeTrip } = useTrip()
   const isErrorInTrip = isErrorGettingTrip || isErrorChangingTrip || !trip
 
@@ -39,14 +39,14 @@ export function OrganiseTripScreen() {
     startTrip()
   }
 
-  const removeLandmarkFromTrip = (landmarkId: string, add: boolean) => {
+  const removeLandmarkFromTrip = (landmarkId: string) => {
     if (trip && trip.landmarks.length > 1) {
       const landmark = trip?.landmarks.find((landmark) => landmark.id === landmarkId)
       if (landmark) {
-        changeTrip({ landmark, addToTrip: add })
+        changeTrip({ landmark, addToTrip: false })
       }
     } else {
-      setShowAlert(true)
+      setShowDeletingNotPossibleAlert(true)
     }
   }
 
@@ -88,7 +88,7 @@ export function OrganiseTripScreen() {
               <IonReorder slot="end"></IonReorder>
             </IonItem>
             <IonItemOptions side="end">
-              <IonItemOption color="danger" onClick={() => removeLandmarkFromTrip(landmark.id, false)}>
+              <IonItemOption color="danger" onClick={() => removeLandmarkFromTrip(landmark.id)}>
                 <IonText>Delete</IonText>
               </IonItemOption>
             </IonItemOptions>
@@ -101,8 +101,8 @@ export function OrganiseTripScreen() {
 
       {/* Alert component */}
       <IonAlert
-        isOpen={showAlert}
-        onDidDismiss={() => setShowAlert(false)}
+        isOpen={showDeletingNotPossibleAlert}
+        onDidDismiss={() => setShowDeletingNotPossibleAlert(false)}
         header="Can't do that right now."
         message="Where would you be going without a landmark?"
         buttons={['OK']}

--- a/src/pages/trip/OrganiseTripScreen.tsx
+++ b/src/pages/trip/OrganiseTripScreen.tsx
@@ -35,10 +35,6 @@ export function OrganiseTripScreen() {
     event.detail.complete()
   }
 
-  function saveTrip() {
-    startTrip()
-  }
-
   const removeLandmarkFromTrip = (landmarkId: string) => {
     if (trip && trip.landmarks.length > 1) {
       const landmark = trip.landmarks.find((landmark) => landmark.id === landmarkId)
@@ -95,7 +91,7 @@ export function OrganiseTripScreen() {
           </IonItemSliding>
         ))}
       </IonReorderGroup>
-      <IonButton className="btn__home btn__download btn__color" routerLink={'/map'} onClick={saveTrip}>
+      <IonButton className="btn__home btn__download btn__color" routerLink={'/map'} onClick={() => startTrip()}>
         Confirm trip
       </IonButton>
 


### PR DESCRIPTION
### 🛠 Changes being made
- Add logic to delete landmark
- Add check so that there's always a landmark in a trip

### ✨ What's the context?
In the OrganiseTripScreen, a user might want to remove a landmark from the trip if fe. the landmark is to far removed from others or other reasons.

At this point in time this is possible by going back a screen and unchecking it there, but a way of doing so in the OrganiseTripScreen would be nice.

### 🧪 Testing
All tests still run.

### 📸 Screenshots (optional)

1) Slider 
![image](https://github.com/BauwenDR/osta/assets/101172722/55c6ddaf-ed73-4f32-9739-df09a8ced27e)

2) Pop up when trying to delete last landmark
![image](https://github.com/BauwenDR/osta/assets/101172722/4c6f47f8-0c6f-41f2-800c-a155d937edb4)

3) New color
![image](https://github.com/BauwenDR/osta/assets/101172722/fa0c9330-3853-46b8-a2eb-058142a1df83)

![image](https://github.com/BauwenDR/osta/assets/101172722/6af2704a-ac9f-4593-bd86-46ec17b4e989)

### 🏎 Quality check
- [x] Are there any errors, console logs, debuggers or leftover code in your changes?
- [x] Did you update the documentation for your code?

### 🐛 Linked issues

- Closes #16 
- Closes #42 